### PR TITLE
switch to private domain for downloads

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
 allprojects {
     repositories {
         maven {
-            url "http://13.42.48.131/artifactory/libs-release-local"
+            url "https://private-cloud-demo-artifactory.sg.dev/artifactory/libs-release-local"
             allowInsecureProtocol = true
             credentials {
                 username = "${artifactoryUsername}" // The publisher user name
@@ -53,7 +53,7 @@ publishing {
 }
 
 artifactory {
-    contextUrl = 'https://13.42.48.131/artifactory'
+    contextUrl = 'http://34.204.212.68/artifactory'
     publish {
         repository {
             repoKey = 'libs-release-local' // The Artifactory repository key to publish to

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ plugins {
 allprojects {
     repositories {
         maven {
+            // for download, private domain
             url "https://private-cloud-demo-artifactory.sg.dev/artifactory/libs-release-local"
             allowInsecureProtocol = true
             credentials {
@@ -36,6 +37,7 @@ apply plugin: 'com.jfrog.artifactory'
 apply plugin: 'java'
 apply plugin: 'maven-publish'
 
+// comment out for initial artifact publish
 dependencies {
     testImplementation 'junit:junit:4.7'
     implementation 'org.gradle.sample:library:1.0'
@@ -53,6 +55,7 @@ publishing {
 }
 
 artifactory {
+    // for publish, public IP with allowlist
     contextUrl = 'http://34.204.212.68/artifactory'
     publish {
         repository {


### PR DESCRIPTION
Switch to use private domain (not resolvable outside of AWS) + some comments.

Verify domain cannot be resolved:
```sh
host private-cloud-demo-artifactory.sg.dev
```

Verify endpoint can be used without allowlist:
```sh
curl 13.42.48.131
```